### PR TITLE
Remove payment info added

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+
+2.0.5 / 2016-08-31
+==================
+
+ * Update PaymentInfoAdded to PaymentInfoEntered [hankim813]
+
 2.0.4 / 2016-08-31
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,12 +72,7 @@ var eventMap = {
     object: 'order',
     action: 'cancelled'
   }],
-  // TODO: change this key to paymentInfoEntered since that's what our docs say
-  // and update any integration using this key as the mapper ie. Facebook Pixel
-  paymentInfoAdded: [{
-    object: 'payment info',
-    action: 'added'
-  }, {
+  paymentInfoEntered: [{
     object: 'payment info',
     action: 'entered'
   }],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "analytics-events",
   "main": "lib/index.js",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "dependencies": {
     "@ndhoule/foldl": "^2.0.1",
     "@ndhoule/map": "^2.0.1"
@@ -22,7 +22,7 @@
     "karma-browserify": "^5.0.4",
     "karma-chrome-launcher": "^1.0.1",
     "karma-coverage": "^1.0.0",
-    "karma-mocha": "^1.0.1",
+    "karma-mocha": "1.0.1",
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-sauce-launcher": "^1.0.0",
     "karma-spec-reporter": "0.0.26",


### PR DESCRIPTION
Our public docs state that we support `Payment Info Entered` but our mapper currently supports incorrectly `Payment Info Added`. We added a quick fix to catch both versions but to remove tech debt we are going to just remove it since nobody is sending `Payment Info Added` events right now anyway.

![](https://i.gyazo.com/daa3bfaebff1028d2bde9a05d1b4a699.png)
_yielded no results_

This release will allow me to merge updates for integrations like [facebook app events](https://github.com/segment-integrations/integration-facebook-app-events/pull/13)

@sperand-io @jgershen @tsholmes 