### PR TITLE
Add 'Video Playback Exited'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,10 @@ var eventMap = {
     object: 'video playback',
     action: 'completed'
   }],
+  videoPlaybackExited: [{
+    object: 'video playback',
+    action: 'exited'
+  }],
   videoPlaybackBufferStarted: [{
     object: 'video playback buffer',
     action: 'started'


### PR DESCRIPTION
This PR adds the new Video Spec event `Video Playback Exited`. This new event has been approved by spec committee, see here: https://paper.dropbox.com/doc/Video-Spec-Event-Proposal-for-Video-Playback-Exited-rUDm4tQEB1RsdH0R7Xujm

All tests passed:
![Screen Shot 2021-04-26 at 6 43 10 PM](https://user-images.githubusercontent.com/49517136/116172923-7c0b9e80-a6c0-11eb-9450-0e9c211f1aba.png)

Confirmed on sourcegraph that `videoPlaybackExited` is not used by any other a.js or cloud integrations. The only place it is used is in analytics-android-integration-nielsen-dcr and analytics-android-integration-nielsen-dtvr, which were updates I made recently and tested. And analytics-roku-integration-adobe-analytics, which contractors built recently for Fox and should not use this package:
![Screen Shot 2021-04-26 at 6 47 34 PM](https://user-images.githubusercontent.com/49517136/116173048-b5440e80-a6c0-11eb-9c66-fd77d8219694.png)
